### PR TITLE
Use strict encoding to encode secret key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 (2018-02-23)
+
+* Use `Base.strict_encode64` to encode the secret key
+
 ## 1.0.1 (2017-02-07)
 
 * Also catch `RbNaCl::LengthError` and wrap it in a `Base64Token::Error`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or install it yourself as:
 # Set the encryption key used for your token. You should store that somewhere
 # if you want to recognize your own tokens at a later time.
 Base64Token.encryption_key = Base64Token.generate_key
-=> "BgPrrt4Ltd7rYlsloSEs+cVuxcaLdjkTRFAjKWViIWo=\n"
+=> "BgPrrt4Ltd7rYlsloSEs+cVuxcaLdjkTRFAjKWViIWo="
 
 token = Base64Token.generate(user_id: 42, valid_to: '2017-01-19T13:37:00')
 => "fTsJg-2iOA5F3YC2i5tlGcWUE-npnZwSEezA-yRfhLL8aV_KE6AuGIZH5YAdgE-lLhiNUmuWCFkxlgUJy7TjdmJFscxzeS-l3CTD1or6nwR0-zHA7B-Q"

--- a/lib/base64_token.rb
+++ b/lib/base64_token.rb
@@ -25,7 +25,9 @@ module Base64Token
     end
 
     def generate_key
-      Base64.encode64(RbNaCl::Random.random_bytes(RbNaCl::SecretBox.key_bytes))
+      Base64.strict_encode64(
+        RbNaCl::Random.random_bytes(RbNaCl::SecretBox.key_bytes)
+      )
     end
 
     def encryption_key=(key)

--- a/lib/base64_token/version.rb
+++ b/lib/base64_token/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Base64Token
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/spec/base64_token_spec.rb
+++ b/spec/base64_token_spec.rb
@@ -2,21 +2,37 @@
 require 'spec_helper'
 
 describe Base64Token do
-  before do
-    described_class.encryption_key = described_class.generate_key
+  before { described_class.encryption_key = described_class.generate_key }
+
+  shared_examples 'valid encryption key' do
+    it 'is able to perform a full roundtrip for a hash' do
+      before = { foo: 'bar' }
+      after = described_class.parse(described_class.generate(before))
+      expect(after).to eql(before)
+    end
+
+    it 'raises for a tampered token' do
+      before = { foo: 'bar' }
+      token = described_class.generate(before)
+      token.insert(5, '1337')
+      expect { described_class.parse(token) }.to raise_error(Base64Token::Error)
+    end
   end
 
-  it 'is able to perform a full roundtrip for a hash' do
-    before = { foo: 'bar' }
-    after = described_class.parse(described_class.generate(before))
-    expect(after).to eql(before)
+  context 'with strict encoded key' do
+    before { described_class.encryption_key = described_class.generate_key }
+
+    it_behaves_like 'valid encryption key'
   end
 
-  it 'raises for a tampered token' do
-    before = { foo: 'bar' }
-    token = described_class.generate(before)
-    token.insert(5, '1337')
-    expect { described_class.parse(token) }.to raise_error(Base64Token::Error)
+  context 'with non-strict encoded key' do
+    before do
+      described_class.encryption_key = Base64.encode64(
+        RbNaCl::Random.random_bytes(RbNaCl::SecretBox.key_bytes)
+      )
+    end
+
+    it_behaves_like 'valid encryption key'
   end
 
   describe '#generate' do


### PR DESCRIPTION
This should be completely backwards compatible, as the only difference is that
`stict_encode64` does not add line feeds. Since `decode64` just ignores
characters outside of the base alphabet it can handle strict and non-strict
encoded keys.

[Base64 documentation](https://docs.ruby-lang.org/en/2.1.0/Base64.html): These methods seem unchanged since at least Ruby 2.1.0

Example that the decoding for both encoded keys leads to the same result:
```rb
irb(main):001:0> key = RbNaCl::Random.random_bytes(RbNaCl::SecretBox.key_bytes)
=> "l[\xA4@]\xB1\xEF\xBB\r\xAA\xEB\xCD\xA0N\xE0_9\xEE\xACHG&o\xC6\xC2\x92\xE9\xF0\a\x15\xAD\xD6"
irb(main):002:0> regular_encoding = Base64.encode64(key)
=> "bFukQF2x77sNquvNoE7gXznurEhHJm/GwpLp8AcVrdY=\n"
irb(main):003:0> strict_encoding = Base64.strict_encode64(key)
=> "bFukQF2x77sNquvNoE7gXznurEhHJm/GwpLp8AcVrdY="
irb(main):004:0> Base64.decode64(regular_encoding) == Base64.decode64(strict_encoding)
=> true
```